### PR TITLE
Fix: Inventory reset not resetting remote companions

### DIFF
--- a/Modules/ManageRemoteCompanions/SubModule.xml
+++ b/Modules/ManageRemoteCompanions/SubModule.xml
@@ -1,0 +1,36 @@
+﻿<Module>
+	<Name value="Manage Remote Companions"/>
+	<Id value="ManageRemoteCompanions"/>
+	<Version value="v2.1.1"/>
+	<SingleplayerModule value="true"/>
+	<MultiplayerModule value="false"/>
+	<Official value="false"/>
+	<DependedModules>
+		<DependedModule Id="Native"/>
+		<DependedModule Id="SandBoxCore"/>
+		<DependedModule Id="Sandbox"/>
+		<DependedModule Id="CustomBattle"/>
+		<DependedModule Id="StoryMode" />
+	</DependedModules>
+	<SubModules>
+		<SubModule>
+			<Name value="ManageRemoteCompanions"/>
+			<DLLName value="ManageRemoteCompanions.dll"/>
+			<SubModuleClassType value="ManageRemoteCompanions.Main"/>
+			<Tags>
+				<Tag key="DedicatedServerType" value="none" />
+				<Tag key="IsNoRenderModeElement" value="false" />
+			</Tags>
+		</SubModule>
+		<SubModule>
+			<Name value="MBOptionScreen" />
+			<DLLName value="MBOptionScreen.dll" />
+			<SubModuleClassType value="MBOptionScreen.MBOptionScreenSubModule" />
+			<Tags>
+				<Tag key="DedicatedServerType" value="none" />
+				<Tag key="IsNoRenderModeElement" value="false" />
+			</Tags>
+		</SubModule>
+	</SubModules>
+	<Xmls/>
+</Module>

--- a/PatchInventoryManager.cs
+++ b/PatchInventoryManager.cs
@@ -1,8 +1,32 @@
 ﻿using HarmonyLib;
+using System.Collections.Generic;
+using System.Linq;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.SandBox.CampaignBehaviors;
+using TaleWorlds.Core;
 
 namespace ManageRemoteCompanions
 {
+    internal class PatchInventoryDefaults
+    {
+        public static Dictionary<CharacterObject, Equipment[]> DefaultCharacterEquipments = new Dictionary<CharacterObject, Equipment[]>();
+
+        public static void SetDefault(CharacterObject character)
+        {
+            DefaultCharacterEquipments[character] = new Equipment[2] { new Equipment(character.Equipment), new Equipment(character.FirstCivilianEquipment) };
+        }
+
+        public static void ResetCharacter(CharacterObject character)
+        {
+            if (DefaultCharacterEquipments.ContainsKey(character))
+            {
+                character.Equipment.FillFrom(DefaultCharacterEquipments[character][0]);
+                character.FirstCivilianEquipment.FillFrom(DefaultCharacterEquipments[character][1]);
+            }
+        }
+    }
+
     [HarmonyPatch(typeof(InventoryLogic), "InitializeRosters")]
     internal class PatchInventoryInit
     {
@@ -12,17 +36,40 @@ namespace ManageRemoteCompanions
             {
                 TroopRoster newRoster = new TroopRoster();
                 newRoster.Add(rightMemberRoster);
+                PatchInventoryDefaults.DefaultCharacterEquipments.Clear();
 
                 foreach (Hero hero in Clan.PlayerClan.Heroes)
+                {
                     if (hero.IsAlive && !hero.IsChild && hero != Hero.MainHero && !newRoster.Contains(hero.CharacterObject))
+                    {
                         newRoster.AddToCounts(hero.CharacterObject, 1);
+                        PatchInventoryDefaults.SetDefault(hero.CharacterObject);
+                    }
+                }
 
                 foreach (Hero hero in Clan.PlayerClan.Companions)
+                {
                     if (hero.IsAlive && hero.IsPlayerCompanion && !newRoster.Contains(hero.CharacterObject))
+                    {
                         newRoster.AddToCounts(hero.CharacterObject, 1);
+                        PatchInventoryDefaults.SetDefault(hero.CharacterObject);
+                    }
+                }
 
                 rightMemberRoster = newRoster;
             }
+        }
+    }
+
+    [HarmonyPatch(typeof(InventoryLogic), "ResetLogic")]
+    internal class PatchInventoryReset
+    {
+        public static void Prefix(InventoryLogic __instance)
+        {
+            if (Settings.Instance.Enabled && Settings.Instance.ApplyInventoryPatch)
+                foreach (CharacterObject c in __instance.RightMemberRoster.Troops)
+                    if (c.IsHero && !__instance.OwnerParty.MemberRoster.Contains(c))
+                        PatchInventoryDefaults.ResetCharacter(c);
         }
     }
 }


### PR DESCRIPTION
Cancelling or Resetting changes made on the inventory screen were not rolling back any changes to remote companion equipment.